### PR TITLE
Fixed priors for gammas: use inverse cov matrix for normal and t. 

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -172,15 +172,27 @@ devech <- function(v, dim) {
     .Call('zoofactr_devech', PACKAGE = 'zoofactr', v, dim)
 }
 
-samplerTest <- function(X, Y, G0, g0, R0, r0, n_draws, burn_in) {
-    .Call('zoofactr_samplerTest', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, n_draws, burn_in)
+samplerTest_normal <- function(X, Y, G0, g0, R0, r0, n_draws, burn_in) {
+    .Call('zoofactr_samplerTest_normal', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, n_draws, burn_in)
 }
 
-logML_SUR <- function(X, Y, G0, g0, R0, r0, n_draws = 5000L, burn_in = 1000L) {
-    .Call('zoofactr_logML_SUR', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, n_draws, burn_in)
+logML_SUR_normal <- function(X, Y, G0, g0, R0, r0, n_draws = 5000L, burn_in = 1000L) {
+    .Call('zoofactr_logML_SUR_normal', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, n_draws, burn_in)
 }
 
-defaultSUR <- function(X, Y, coef_scale = 10, cov_scale = 10) {
-    .Call('zoofactr_defaultSUR', PACKAGE = 'zoofactr', X, Y, coef_scale, cov_scale)
+defaultSUR_normal <- function(X, Y, coef_scale = 10, cov_scale = 10) {
+    .Call('zoofactr_defaultSUR_normal', PACKAGE = 'zoofactr', X, Y, coef_scale, cov_scale)
+}
+
+samplerTest_t <- function(X, Y, G0, g0, R0, r0, nu, n_draws, burn_in) {
+    .Call('zoofactr_samplerTest_t', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, nu, n_draws, burn_in)
+}
+
+logML_SUR_t <- function(X, Y, G0, g0, R0, r0, nu, n_draws = 5000L, burn_in = 1000L) {
+    .Call('zoofactr_logML_SUR_t', PACKAGE = 'zoofactr', X, Y, G0, g0, R0, r0, nu, n_draws, burn_in)
+}
+
+defaultSUR_t <- function(X, Y, coef_scale = 10, cov_scale = 10) {
+    .Call('zoofactr_defaultSUR_t', PACKAGE = 'zoofactr', X, Y, coef_scale, cov_scale)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -131,9 +131,9 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
-// samplerTest
-List samplerTest(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int n_draws, int burn_in);
-RcppExport SEXP zoofactr_samplerTest(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
+// samplerTest_normal
+List samplerTest_normal(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int n_draws, int burn_in);
+RcppExport SEXP zoofactr_samplerTest_normal(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
@@ -145,13 +145,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type r0(r0SEXP);
     Rcpp::traits::input_parameter< int >::type n_draws(n_drawsSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
-    __result = Rcpp::wrap(samplerTest(X, Y, G0, g0, R0, r0, n_draws, burn_in));
+    __result = Rcpp::wrap(samplerTest_normal(X, Y, G0, g0, R0, r0, n_draws, burn_in));
     return __result;
 END_RCPP
 }
-// logML_SUR
-double logML_SUR(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int n_draws, int burn_in);
-RcppExport SEXP zoofactr_logML_SUR(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
+// logML_SUR_normal
+double logML_SUR_normal(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int n_draws, int burn_in);
+RcppExport SEXP zoofactr_logML_SUR_normal(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
@@ -163,13 +163,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type r0(r0SEXP);
     Rcpp::traits::input_parameter< int >::type n_draws(n_drawsSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
-    __result = Rcpp::wrap(logML_SUR(X, Y, G0, g0, R0, r0, n_draws, burn_in));
+    __result = Rcpp::wrap(logML_SUR_normal(X, Y, G0, g0, R0, r0, n_draws, burn_in));
     return __result;
 END_RCPP
 }
-// defaultSUR
-List defaultSUR(arma::mat X, arma::mat Y, double coef_scale, double cov_scale);
-RcppExport SEXP zoofactr_defaultSUR(SEXP XSEXP, SEXP YSEXP, SEXP coef_scaleSEXP, SEXP cov_scaleSEXP) {
+// defaultSUR_normal
+List defaultSUR_normal(arma::mat X, arma::mat Y, double coef_scale, double cov_scale);
+RcppExport SEXP zoofactr_defaultSUR_normal(SEXP XSEXP, SEXP YSEXP, SEXP coef_scaleSEXP, SEXP cov_scaleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
@@ -177,7 +177,59 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::mat >::type Y(YSEXP);
     Rcpp::traits::input_parameter< double >::type coef_scale(coef_scaleSEXP);
     Rcpp::traits::input_parameter< double >::type cov_scale(cov_scaleSEXP);
-    __result = Rcpp::wrap(defaultSUR(X, Y, coef_scale, cov_scale));
+    __result = Rcpp::wrap(defaultSUR_normal(X, Y, coef_scale, cov_scale));
+    return __result;
+END_RCPP
+}
+// samplerTest_t
+List samplerTest_t(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int nu, int n_draws, int burn_in);
+RcppExport SEXP zoofactr_samplerTest_t(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP nuSEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< arma::mat >::type X(XSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type G0(G0SEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type g0(g0SEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type R0(R0SEXP);
+    Rcpp::traits::input_parameter< int >::type r0(r0SEXP);
+    Rcpp::traits::input_parameter< int >::type nu(nuSEXP);
+    Rcpp::traits::input_parameter< int >::type n_draws(n_drawsSEXP);
+    Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
+    __result = Rcpp::wrap(samplerTest_t(X, Y, G0, g0, R0, r0, nu, n_draws, burn_in));
+    return __result;
+END_RCPP
+}
+// logML_SUR_t
+double logML_SUR_t(arma::mat X, arma::mat Y, arma::mat G0, arma::vec g0, arma::mat R0, int r0, int nu, int n_draws, int burn_in);
+RcppExport SEXP zoofactr_logML_SUR_t(SEXP XSEXP, SEXP YSEXP, SEXP G0SEXP, SEXP g0SEXP, SEXP R0SEXP, SEXP r0SEXP, SEXP nuSEXP, SEXP n_drawsSEXP, SEXP burn_inSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< arma::mat >::type X(XSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type G0(G0SEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type g0(g0SEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type R0(R0SEXP);
+    Rcpp::traits::input_parameter< int >::type r0(r0SEXP);
+    Rcpp::traits::input_parameter< int >::type nu(nuSEXP);
+    Rcpp::traits::input_parameter< int >::type n_draws(n_drawsSEXP);
+    Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
+    __result = Rcpp::wrap(logML_SUR_t(X, Y, G0, g0, R0, r0, nu, n_draws, burn_in));
+    return __result;
+END_RCPP
+}
+// defaultSUR_t
+List defaultSUR_t(arma::mat X, arma::mat Y, double coef_scale, double cov_scale);
+RcppExport SEXP zoofactr_defaultSUR_t(SEXP XSEXP, SEXP YSEXP, SEXP coef_scaleSEXP, SEXP cov_scaleSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< arma::mat >::type X(XSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< double >::type coef_scale(coef_scaleSEXP);
+    Rcpp::traits::input_parameter< double >::type cov_scale(cov_scaleSEXP);
+    __result = Rcpp::wrap(defaultSUR_t(X, Y, coef_scale, cov_scale));
     return __result;
 END_RCPP
 }

--- a/src/sampler_normal.cpp
+++ b/src/sampler_normal.cpp
@@ -36,7 +36,6 @@ SURnormal::SURnormal(const arma::mat& X, const arma::mat& Y,
   r0copy = r0;
   G0copy = G0;
   g0copy = g0;
-  r0copy = r0;
   R0copy = R0;
   Xcopy = X;
   Ycopy = Y;
@@ -73,7 +72,7 @@ double SURnormal::logML(){
   arma::mat Omega_inv_star = devech(mean(Omega_inv_draws, 1), D);
 
   double prior1 = as_scalar(density_normal(gstar, g0copy,
-                                           G0copy, true));
+                                           inv_sympd(G0copy), true));
   double prior2 = density_wishart(Omega_inv_star, r0copy,
                                   R0copy, true);
 

--- a/src/sampler_t.cpp
+++ b/src/sampler_t.cpp
@@ -60,7 +60,7 @@ SURt::SURt(const arma::mat& X, const arma::mat& Y, const arma::mat& G0,
     R_Tlambda = inv_sympd(R0_inv + resid.t() * arma::diagmat(lambda) * resid);
     Omega_inv = draw_wishart(r1, R_Tlambda);
     //draw lambda
-    lambda = draw_gamma(a1, 0.5 * (nu + arma::sum(arma::pow(resid, 2), 2)));
+    lambda = draw_gamma(a1, 0.5 * (nu + vectorise(arma::sum(arma::pow(resid, 2), 1))));
 
     if(i >= burn_in){
       j = i - burn_in;
@@ -78,7 +78,7 @@ double SURt::logML(){
   arma::mat Omega_inv_star = devech(mean(Omega_inv_draws, 1), D);
 
   //Contribution of prior - identical to model with normal likelihood
-  double prior1 = as_scalar(density_normal(gstar, g0, G0, true));
+  double prior1 = as_scalar(density_normal(gstar, g0, inv_sympd(G0), true));
   double prior2 = density_wishart(Omega_inv_star, r0, R0, true);
 
   //Residuals evaluated at posterior mean of gamma: each row is a time period


### PR DESCRIPTION
Removed repeating line in normal sampler. 
Adjusted dimensionality of rate parameter vector in t sampler for lambdas
